### PR TITLE
This PR contains:

### DIFF
--- a/src/lib/Table/Table.js
+++ b/src/lib/Table/Table.js
@@ -209,7 +209,7 @@ export default class Table extends React.Component {
         }
 
         if (this.autoScrolling && this.props.autoScroll && this.props.data) {
-            this.scrollToItem(this.props.data.size);
+            this.scrollToItem(this.getDataSize());
         }
     }
 


### PR DESCRIPTION
- Fix for crash when `autoScroll` is set to `true`, but the passed data is an array and the `size` attribute is absent.